### PR TITLE
Github Action 现不支持 macos13, 更新到 macos15-intel 可以正常release

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -35,7 +35,7 @@ jobs:
         - os: macos-14
           version: mac_apple
           pythonArch: arm64
-        - os: macos-13
+        - os: macos-15-intel
           version: mac_intel
           pythonArch: x64
         - os: ubuntu-22.04


### PR DESCRIPTION
<img width="698" height="165" alt="image" src="https://github.com/user-attachments/assets/5cba8898-1e72-41fb-ab72-772197e53dba" />
