### PR TITLE
fix: use correct OAuth endpoint for token exchange and add login retry

### DIFF
--- a/app/config/language/en.yml
+++ b/app/config/language/en.yml
@@ -51,3 +51,4 @@ app.common.loginHelper:
     hint_intro_step_7: "7. Enter the parameter after 'code' into this program"
     fail_code_918: "Code error. Note that the Code required each time the program starts is different, cannot reuse previously obtained Codes, and codes do not include quotation marks."
     fail_code_1508: "Code has expired. Please be quicker when obtaining the code."
+    is_retry: "Retry? You will need to reopen the login link to get a new Code (y / n): "

--- a/app/config/language/es.yml
+++ b/app/config/language/es.yml
@@ -51,3 +51,4 @@ app.common.loginHelper:
     hint_intro_step_7: "7. Introduzca el parámetro después de [código] en este programa"
     fail_code_918: "Error de código. Tenga en cuenta que el programa requiere un código diferente cada vez que se inicia y que el código no contiene comillas."
     fail_code_1508: "Código expirado. Por favor, intenta ser un poco más rápido al realizar la operación de obtención del código."
+    is_retry: "¿Reintentar? Deberá volver a abrir el enlace de inicio de sesión para obtener un nuevo código (y / n): "

--- a/app/config/language/zh-TW.yml
+++ b/app/config/language/zh-TW.yml
@@ -51,3 +51,4 @@ app.common.loginHelper:
     hint_intro_step_7: "7. 將「code」後面的參數輸入本程式"
     fail_code_918: "Code 錯誤。請注意程式每次啟動時要求獲取的 Code 都不同，不可重複使用之前獲取到的，且 Code 不帶有引號。"
     fail_code_1508: "Code 已過期。請在進行 Code 獲取操作時快一些。"
+    is_retry: "是否重試? 重試時需要重新打開登入連結獲取新的 Code (y / n): "

--- a/app/config/language/zh.yml
+++ b/app/config/language/zh.yml
@@ -51,3 +51,4 @@ app.common.loginHelper:
     hint_intro_step_7: "7. 将「code」后面的参数输入本程序"
     fail_code_918: "Code 错误。请注意程序每次启动时要求获取的 Code 都不同，不可复用之前获取到的，且 Code 不带有引号。"
     fail_code_1508: "Code 已过期。请在进行 Code 获取操作时快一些。"
+    is_retry: "是否重试? 重试时需要重新打开登录链接获取新的 Code (y / n): "

--- a/app/lib/common/login_helper/main.py
+++ b/app/lib/common/login_helper/main.py
@@ -1,7 +1,7 @@
 import requests
 
 from altfe.interface.root import interRoot
-from app.lib.common.login_helper.token import TokenGetter
+from app.lib.common.login_helper.token import AUTH_TOKEN_URL_HOST, TokenGetter
 from app.v2.utils.sprint import SPrint
 
 _ln = lambda val, header="Login Helper": print(f"[{header}] " + val if header else val)
@@ -38,7 +38,10 @@ class CommonLoginHelper(interRoot):
         :param proxy_: 代理设置，auto 为程序自动判断
         :return: bool
         """
+        self.auth_token_url = AUTH_TOKEN_URL_HOST
+
         if is_no_proxy:
+            self.proxy = ""
             return self._test_pixiv_connection(proxy="")
 
         is_pixiv_accessible = True
@@ -61,7 +64,6 @@ class CommonLoginHelper(interRoot):
 
         # For now, the bypass mode is disabled
         self.proxy = proxy
-        self.auth_token_url = self.SOME_URLS[0]
 
         if not is_silent:
             _ln(
@@ -100,9 +102,10 @@ class CommonLoginHelper(interRoot):
 
         # return False
 
-    def login(self):
+    def login(self, max_retries=3):
         """
-        登陆操作。
+        登陆操作。支持多次重试，避免用户因输入错误需要重启程序。
+        :param max_retries: 最大重试次数
         :return: tuple(access token, refresh token, user id) || tuple(false, false, false)
         """
         kw = (
@@ -110,18 +113,26 @@ class CommonLoginHelper(interRoot):
             if self.proxy != ""
             else {}
         )
-        try:
-            return self.token_getter.login(
-                host=self.auth_token_url, newCode=True, kw=kw
-            )
-        except Exception as e:
-            err = str(e)
-            if "'code': 918" in err:
-                self.STATIC.localMsger.red(self.lang("login.fail_code_918"))
-            elif "'code': 1508" in err:
-                self.STATIC.localMsger.red(self.lang("login.fail_code_1508"))
-            else:
-                self.STATIC.localMsger.error(e, header=False)
+        for attempt in range(max_retries):
+            try:
+                return self.token_getter.login(
+                    host=self.auth_token_url, newCode=True, kw=kw
+                )
+            except Exception as e:
+                err = str(e)
+                if "'code': 918" in err:
+                    self.STATIC.localMsger.red(self.lang("login.fail_code_918"))
+                elif "'code': 1508" in err:
+                    self.STATIC.localMsger.red(self.lang("login.fail_code_1508"))
+                else:
+                    self.STATIC.localMsger.error(e, header=False)
+
+                if attempt < max_retries - 1:
+                    retry = input(self.lang("login.is_retry"))
+                    if retry not in ["y", ""]:
+                        break
+                    # 重试时需要重新生成 PKCE 参数，因为之前的 code 已关联旧的 code_challenge
+                    self.token_getter.regenerate_pkce()
         return False, False, False
 
     def refresh(self, refresh_token):
@@ -176,7 +187,7 @@ class CommonLoginHelper(interRoot):
         return self.proxy
 
     def is_bypass(self) -> bool:
-        return self.auth_token_url != self.SOME_URLS[0]
+        return self.auth_token_url != AUTH_TOKEN_URL_HOST
 
     @classmethod
     def _test_access(cls, url: str, proxy: str = "", is_silent: bool = False):

--- a/app/lib/common/login_helper/token.py
+++ b/app/lib/common/login_helper/token.py
@@ -28,6 +28,16 @@ class TokenGetter(object):
             "client": "pixiv-android",
         }
 
+    def regenerate_pkce(self):
+        """重新生成 PKCE 参数，用于重试登录时确保 code_verifier 和 code_challenge 匹配。"""
+        self.code = ""
+        self.code_verifier, self.code_challenge = self.oauth_pkce(self.s256)
+        self.login_params = {
+            "code_challenge": self.code_challenge,
+            "code_challenge_method": "S256",
+            "client": "pixiv-android",
+        }
+
     def s256(self, data):
         """S256 transformation method."""
 
@@ -67,8 +77,9 @@ class TokenGetter(object):
             code = input("Code: ").strip()
         self.code = code
 
+        token_url = "%s/auth/token" % host
         response = self.requests.post(
-            "%s/auth/token" % host,
+            token_url,
             data={
                 "client_id": CLIENT_ID,
                 "client_secret": CLIENT_SECRET,
@@ -85,7 +96,10 @@ class TokenGetter(object):
         rst = response.json()
         if "access_token" in rst and "refresh_token" in rst:
             return rst["access_token"], rst["refresh_token"], rst["user"]["id"]
-        raise Exception("Request Error.\nResponse: " + str(rst))
+        raise Exception(
+            "Request Error (HTTP %d, %s).\nResponse: %s"
+            % (response.status_code, token_url, str(rst))
+        )
 
     def refresh(self, refresh_token, host=AUTH_TOKEN_URL_HOST, kw={}):
         """


### PR DESCRIPTION
The token exchange was sending requests to public-api.secure.pixiv.net
instead of oauth.secure.pixiv.net, causing intermittent 918 errors
depending on CDN/server routing. Also fixed check_network early return
leaving auth_token_url uninitialized when proxy was set to "no".

Added retry mechanism (up to 3 attempts) so users don't need to restart
the entire application on login failure, and improved error messages to
include HTTP status and endpoint URL for easier diagnostics.

https://claude.ai/code/session_01H6p9TSeaszCSyVNqgg4W3f